### PR TITLE
Fixed a typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ scrollbar-width-{spacing}: width of scrollbar
 scrollbar-track-{color}: color of track/bar
 scrollbar-thumb-{color}: color of thumb/handle
 scrollbar-track-radius-{borderRadius}: border radius of track/bar
-scrollbar-thumb-{color}: border radius of thumb/handle
+scrollbar-thumb-radius-{borderRadius}: border radius of thumb/handle
 
 then there are variants for above properties such as: hover, color, x, y
 


### PR DESCRIPTION
The border radius class of the thumb was accidentally written `scrollbar-thumb-{color}`, instead of `scrollbar-thumb-radius-{borderRadius}`.

Please merge this pull request :)